### PR TITLE
Optimization of setting network

### DIFF
--- a/cmd/netinit/netinit.go
+++ b/cmd/netinit/netinit.go
@@ -1,6 +1,7 @@
 package netinit
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/niusmallnan/k3os/config"
@@ -16,7 +17,7 @@ func Main() {
 	app.EnableBashCompletion = true
 	app.HideHelp = true
 	app.Name = os.Args[0]
-	app.Usage = "k3os network init"
+	app.Usage = fmt.Sprintf("%s K3OS(%s)", app.Name, config.OSBuildDate)
 	app.Version = config.OSVersion
 	app.Action = netInit
 	app.Run(os.Args)

--- a/cmd/sysinit/sysinit.go
+++ b/cmd/sysinit/sysinit.go
@@ -1,6 +1,7 @@
 package sysinit
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/niusmallnan/k3os/config"
@@ -21,7 +22,7 @@ func Main() {
 	app.EnableBashCompletion = true
 	app.HideHelp = true
 	app.Name = os.Args[0]
-	app.Usage = "k3os system init"
+	app.Usage = fmt.Sprintf("%s K3OS(%s)", app.Name, config.OSBuildDate)
 	app.Version = config.OSVersion
 	app.Action = sysInit
 	app.Run(os.Args)

--- a/cmd/ttyinit/ttyinit.go
+++ b/cmd/ttyinit/ttyinit.go
@@ -46,7 +46,7 @@ func Main() {
 	app := cli.NewApp()
 
 	app.Name = os.Args[0]
-	app.Usage = fmt.Sprintf("%s K3OS\nbuilt: %s", app.Name, config.OSBuildDate)
+	app.Usage = fmt.Sprintf("%s K3OS(%s)", app.Name, config.OSBuildDate)
 	app.Version = config.OSVersion
 	app.Author = "Rancher Labs, Inc."
 

--- a/config/schema.go
+++ b/config/schema.go
@@ -125,6 +125,9 @@ var schema = `{
         },
         "gateway": {
           "type": "string"
+        },
+        "metric": {
+         "type": "integer"
         }
       }
     },

--- a/config/types.go
+++ b/config/types.go
@@ -46,6 +46,7 @@ type DNSConfig struct {
 type InterfaceConfig struct {
 	Addresses []string `yaml:"addresses,flow,omitempty"`
 	Gateway   string   `yaml:"gateway,omitempty"`
+	Metric    int      `yaml:"metric,omitempty"`
 }
 
 type K3OSConfig struct {

--- a/pkg/network/dhcpcd.go
+++ b/pkg/network/dhcpcd.go
@@ -8,34 +8,34 @@ import (
 	"strings"
 )
 
-func CheckDhcpcd() error {
+func CheckDhcpcd() (bool, error) {
 	cmd := exec.Command("/bin/sh", "-c", `ps aux | grep "dhcpcd"`)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return err
+		return false, err
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := cmd.Start(); err != nil {
-		return err
+		return false, err
 	}
 	bytesErr, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(bytesErr) != 0 {
-		return errors.New(string(bytesErr))
+		return false, errors.New(string(bytesErr))
 	}
 	bytes, err := ioutil.ReadAll(stdout)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if strings.Contains(string(bytes), "/sbin/dhcpcd") {
-		return errors.New("dhcpcd process is still running")
+	if !strings.Contains(string(bytes), "/sbin/dhcpcd") {
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 func ReleaseDhcpcd(iface string) error {
@@ -55,8 +55,12 @@ func ReleaseDhcpcd(iface string) error {
 	return nil
 }
 
-func StartDhcpcd() error {
-	cmd := exec.Command("/sbin/dhcpcd", "-f", "/etc/dhcpcd.conf")
+func StartDhcpcd(arguments []string) error {
+	args := []string{"-f", "/etc/dhcpcd.conf"}
+	if len(arguments) > 0 {
+		args = append(args, arguments...)
+	}
+	cmd := exec.Command("/sbin/dhcpcd", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -70,6 +74,19 @@ func StartDhcpcd() error {
 
 func StopDhcpcd() error {
 	cmd := exec.Command("/sbin/dhcpcd", "-x")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func RequestDhcpcd(iface string) error {
+	cmd := exec.Command("/sbin/dhcpcd", "-A4", iface)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"syscall"
 
 	"github.com/niusmallnan/k3os/config"
@@ -13,53 +14,151 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
-var defaultMetric = 400
-
 func SettingNetwork(cfg *config.CloudConfig) error {
 	interfaces := cfg.K3OS.Network.Interfaces
-	if len(interfaces) > 0 {
-		if err := ReleaseDhcpcd(""); err != nil {
-			// consider no running dhcpcd process situation, so ignore the error
-			logrus.Errorf("failed to release dhcpcd, network setting will be continue: %v", err)
-		}
-		if err := CheckDhcpcd(); err != nil {
-			return err
-		}
-		// remove useless default gateway
-		if err := removeGateway(); err != nil {
-			return err
-		}
-		for k, v := range interfaces {
-			link, err := netlink.LinkByName(k)
-			if err != nil || link == nil {
-				logrus.Errorf("interface %s not exist", k)
-				continue
-			}
-			// remove all useless address on specific interface
-			if err := removeAddresses(link); err != nil {
+	links, err := getLinkList()
+	if err != nil {
+		return err
+	}
+	exist, err := CheckDhcpcd()
+	if err != nil {
+		return err
+	}
+	// dhcp mode on all interfaces
+	if len(interfaces) <= 0 {
+		if !exist {
+			// cleanup network settings
+			if err := cleanupSettings(links); err != nil {
 				return err
 			}
-			if len(v.Addresses) <= 0 {
-				return fmt.Errorf("interface %s addresses property length is 0", k)
+			// start dhcpcd process
+			if err := StartDhcpcd([]string{}); err != nil {
+				return fmt.Errorf("failed to start dhcpcd: %v", err)
 			}
-			for _, addr := range v.Addresses {
-				// setting address to specific interface
-				if err := settingAddress(link, addr); err != nil {
+		}
+		logrus.Infoln("all link will use dhcp mode")
+	} else {
+		// find links which is dhcp mode
+		dLinks := findDhcpLinks(interfaces, links)
+		// no interface use dhcp
+		if len(dLinks) <= 0 {
+			if err := ReleaseDhcpcd(""); err != nil {
+				// consider no running dhcpcd process situation, so ignore the error
+				logrus.Warnf("failed to release dhcpcd, network setting will be continue: %v", err)
+			}
+			reCheck, err := CheckDhcpcd()
+			if err != nil {
+				return err
+			}
+			if reCheck {
+				return errors.New("dhcpcd process is still running")
+			}
+		} else {
+			reCheck, err := CheckDhcpcd()
+			if err != nil {
+				return err
+			}
+			if !reCheck {
+				// make sure dhcpcd process exist when execute k3os-netinit with no reboot
+				// -w wait for an address to be assigned before forking to the background
+				if err := StartDhcpcd([]string{"-w"}); err != nil {
 					return err
 				}
 			}
-			// setting default gateway with metric property
-			if err := settingGateway(v.Gateway, link); err != nil {
+			// release dhcp for interface which not use dhcp mode
+			for k := range interfaces {
+				link, err := netlink.LinkByName(k)
+				if err != nil || link == nil {
+					logrus.Warnf("interface %s not exist", k)
+					continue
+				}
+				if err := ReleaseDhcpcd(k); err != nil {
+					// consider no running dhcpcd process situation, so ignore the error
+					logrus.Warnf("failed to release dhcp on link %s , network setting will be continue: %v", k, err)
+				}
+			}
+		}
+		// cleanup network settings
+		if err := cleanupSettings(links); err != nil {
+			return err
+		}
+		// setting cloud-config address for interface
+		if err := applySettings(interfaces); err != nil {
+			return err
+		}
+		// setting dhcp address for interface
+		for _, link := range dLinks {
+			logrus.Infof("link %s will use dhcp mode", link.Attrs().Name)
+			if err := RequestDhcpcd(link.Attrs().Name); err != nil {
 				return err
 			}
 		}
-	} else {
-		// start dhcpcd process, ignore the prev-settings which will be clean after reboot
-		if err := StartDhcpcd(); err != nil {
-			return fmt.Errorf("failed to start dhcpcd: %v", err)
+	}
+	return nil
+}
+
+func applySettings(interfaces map[string]config.InterfaceConfig) error {
+	for k, v := range interfaces {
+		link, err := netlink.LinkByName(k)
+		if err != nil || link == nil {
+			logrus.Warnf("interface %s not exist", k)
+			continue
+		}
+		if len(v.Addresses) <= 0 {
+			return fmt.Errorf("interface %s addresses property length is 0", k)
+		}
+		for _, addr := range v.Addresses {
+			// setting address to specific interface
+			if err := settingAddress(link, addr); err != nil {
+				return err
+			}
+		}
+		// setting default gateway with metric property
+		if err := settingGateway(v.Gateway, v.Metric, link); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func cleanupSettings(links []netlink.Link) error {
+	// remove useless default gateway
+	if err := removeGateway(); err != nil {
+		return err
+	}
+	for _, link := range links {
+		// remove all useless address on specific interface
+		if err := removeAddresses(link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findDhcpLinks(interfaces map[string]config.InterfaceConfig, links []netlink.Link) []netlink.Link {
+	dhcpLinks := make([]netlink.Link, 0)
+	for _, link := range links {
+		if _, ok := interfaces[link.Attrs().Name]; !ok {
+			dhcpLinks = append(dhcpLinks, link)
+		}
+	}
+	return dhcpLinks
+}
+
+func getLinkList() ([]netlink.Link, error) {
+	var valid []netlink.Link
+	links, err := netlink.LinkList()
+	if err != nil {
+		return valid, err
+	}
+	for _, l := range links {
+		name := l.Attrs().Name
+		if name == "lo" || strings.Contains(name, "flannel") || strings.Contains(name, "veth") {
+			continue
+		}
+		valid = append(valid, l)
+	}
+	return valid, nil
 }
 
 func removeAddresses(link netlink.Link) error {
@@ -101,7 +200,7 @@ func settingAddress(link netlink.Link, address string) error {
 	return nil
 }
 
-func settingGateway(gateway string, link netlink.Link) error {
+func settingGateway(gateway string, metric int, link netlink.Link) error {
 	if gateway == "" {
 		logrus.Warnf("interface %s's gateway property is not setting", link.Attrs().Name)
 		return nil
@@ -110,17 +209,20 @@ func settingGateway(gateway string, link netlink.Link) error {
 	if gw == nil {
 		return errors.New("invalid gateway address: " + gateway)
 	}
-
 	// Metrics are used to prefer an interface over another one, lowest wins.
 	//  Dhcpcd will supply a default metric	of 200 + if_nametoindex(3).
 	//  An extra 100 will be added for wireless interfaces.
 	// Reference: dhcpcd.conf.5
-	route := netlink.Route{
-		Scope:    netlink.SCOPE_UNIVERSE,
-		Gw:       gw,
-		Priority: defaultMetric + link.Attrs().Index,
+	priority := 400 + link.Attrs().Index
+	if metric > 0 {
+		priority = metric
 	}
-
+	route := netlink.Route{
+		Scope: netlink.SCOPE_UNIVERSE,
+		Gw:    gw,
+		// cloud-config user-defined gateway begin with 400 + if_nametoindex(3)
+		Priority: priority,
+	}
 	if err := netlink.RouteAdd(&route); err != nil && err != syscall.EEXIST {
 		return err
 	}


### PR DESCRIPTION
### Description:
Support both setting DHCP and static address on muti-interfaces

### Interfaces Info:
- enp0s3: STATIC mode
- enp0s8: STATIC mode
- enp0s9: DHCP mode

### Full configuration:
```
k3os:
  network:
    dns:
      nameservers:
      - 10.22.0.1
      - 8.8.4.4
      searches:
      - expressvpn
    interfaces:
      enp0s3:
        addresses:
        - 10.0.2.20/24
        gateway: 10.0.2.2
        metric: 180 # if metric not setting, will use default value: 400 + interface_index
      enp0s8:
        addresses:
        - 10.0.3.21/24
        gateway: 10.0.3.2
```
### Take configuration effect:
```
$ reboot
```
or
```
$ k3os-netinit
```

### Limitations:
- Local-Link configuration should be considered